### PR TITLE
Update code style and deprecate cartesian_product function

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   code-style:
-    name: Code Style & Static Analysis
+    name: Code Style
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,7 +27,7 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Check code style
-        run: vendor/bin/phpcs --standard=psr2 -n src/
+        run: vendor/bin/php-cs-fixer check
 
 
   tests:

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,39 @@
+<?php
+
+$finder = (new PhpCsFixer\Finder())
+    ->in(__DIR__)
+    ->exclude('var')
+    ->exclude('src/Swagger')
+;
+
+return (new PhpCsFixer\Config())
+    ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
+    ->setRules([
+        'array_syntax' => ['syntax' => 'short'],
+        'ordered_class_elements' => true,
+        'global_namespace_import' => true,
+        'phpdoc_to_comment' => ['ignored_tags' => ['var']],
+        'linebreak_after_opening_tag' => true,
+        'mb_str_functions' => true,
+        'no_php4_constructor' => true,
+        'no_unreachable_default_argument_value' => true,
+        'no_useless_else' => true,
+        'no_useless_return' => true,
+        'phpdoc_order' => true,
+        'strict_comparison' => true,
+        'strict_param' => true,
+        'blank_line_between_import_groups' => true,
+        'single_line_throw' => false,
+        'single_line_empty_body' => true,
+        'nullable_type_declaration_for_default_null_value'  => true,
+        'array_indentation' => false,
+        'ordered_types' => false,
+        'phpdoc_scalar' => false,
+        'fully_qualified_strict_types' => false,
+        'blank_line_after_opening_tag' => false,
+        'nullable_type_declaration' => false,
+        'native_function_invocation' => false,
+    ])
+    ->setFinder($finder)
+    ->setRiskyAllowed(true)
+;

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Usage
 ```php
 require_once __DIR__ . '/vendor/autoload.php';
 
-use function BenTools\CartesianProduct\cartesian_product;
+use function BenTools\CartesianProduct\combinations;
 
 $data = [
     'hair' => [
@@ -33,7 +33,7 @@ $data = [
     ]
 ];
 
-foreach (cartesian_product($data) as $combination) {
+foreach (combinations($data) as $combination) {
     printf('Hair: %s - Eyes: %s' . PHP_EOL, $combination['hair'], $combination['eyes']);
 }
 ```
@@ -53,8 +53,11 @@ Array output
 
 Instead of using `foreach` you can dump all possibilities into an array.
 
+> [!WARNING]
+> This will dump all combinations in memory, so be careful with large datasets.
+
 ```php
-print_r(cartesian_product($data)->asArray());
+print_r(combinations($data)->asArray());
 ```
 
 Output:
@@ -109,7 +112,7 @@ You can simply count how many combinations your data produce:
 ```php
 require_once __DIR__ . '/vendor/autoload.php';
 
-use function BenTools\CartesianProduct\cartesian_product;
+use function BenTools\CartesianProduct\combinations;
 
 $data = [
     'hair' => [
@@ -126,7 +129,7 @@ $data = [
         'female',
     ]
 ];
-var_dump(count(cartesian_product($data))); // 2 * 3 * 2 = 12
+var_dump(count(combinations($data))); // 2 * 3 * 2 = 12
 ```
 
 
@@ -144,12 +147,12 @@ The following example was executed on my Core i7 personnal computer with 8GB RAM
 
 ```php
 require_once __DIR__ . '/vendor/autoload.php';
-use function BenTools\CartesianProduct\cartesian_product;
+use function BenTools\CartesianProduct\combinations;
 
 $data = array_fill(0, 10, array_fill(0, 5, 'foo'));
 
 $start = microtime(true);
-foreach (cartesian_product($data) as $c => $combination) {
+foreach (combinations($data) as $c => $combination) {
     continue;
 }
 $end = microtime(true);

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,7 @@
         "php": ">=7.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0|^9.0",
-        "squizlabs/php_codesniffer": "@stable",
-        "php-coveralls/php-coveralls": "@stable",
-        "symfony/var-dumper": "^3.2|^4.0",
-        "dms/phpunit-arraysubset-asserts": "^0.3.1"
+        "symfony/var-dumper": "^6.0|^7.0",
+        "phpunit/phpunit": "^9.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     },
     "require-dev": {
         "symfony/var-dumper": "^6.0|^7.0",
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^9.0",
+        "friendsofphp/php-cs-fixer": "^3.82"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" beStrictAboutTestsThatDoNotTestAnything="true" beStrictAboutOutputDuringTests="true" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" failOnRisky="true" failOnWarning="true" processIsolation="false" stopOnError="false" stopOnFailure="false" verbose="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-  </coverage>
-  <testsuites>
-    <testsuite name="Test Suite">
-      <file>tests/TestCartesianProduct.php</file>
-    </testsuite>
-  </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false"
+         beStrictAboutTestsThatDoNotTestAnything="true" beStrictAboutOutputDuringTests="true"
+         bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true" convertWarningsToExceptions="true" failOnRisky="true" failOnWarning="true"
+         processIsolation="false" stopOnError="false" stopOnFailure="false" verbose="true" convertDeprecationsToExceptions="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
+    <testsuites>
+        <testsuite name="New function">
+            <file>tests/TestCombinationsFunction.php</file>
+        </testsuite>
+        <testsuite name="Legacy function">
+            <file>tests/TestCartesianProductFunction.php</file>
+        </testsuite>
+    </testsuites>
 </phpunit>

--- a/src/CartesianProduct.php
+++ b/src/CartesianProduct.php
@@ -66,6 +66,28 @@ final class CartesianProduct implements IteratorAggregate, Countable
     }
 
     /**
+     * @return array<array<TKey, TValue>>
+     */
+    public function asArray(): array
+    {
+        return iterator_to_array($this);
+    }
+
+    public function count(): int
+    {
+        return $this->count ??= (int) array_product(
+            array_map(
+                function ($subset, $key) {
+                    $this->validate($subset, $key);
+                    return count($subset);
+                },
+                $this->set,
+                array_keys($this->set)
+            )
+        );
+    }
+
+    /**
      * @param mixed $subset
      * @param TKey $key
      */
@@ -94,27 +116,5 @@ final class CartesianProduct implements IteratorAggregate, Countable
         $product->isRecursiveStep = true;
 
         return $product;
-    }
-
-    /**
-     * @return array<array<TKey, TValue>>
-     */
-    public function asArray(): array
-    {
-        return iterator_to_array($this);
-    }
-
-    public function count(): int
-    {
-        return $this->count ??= (int) array_product(
-            array_map(
-                function ($subset, $key) {
-                    $this->validate($subset, $key);
-                    return count($subset);
-                },
-                $this->set,
-                array_keys($this->set)
-            )
-        );
     }
 }

--- a/src/CartesianProduct.php
+++ b/src/CartesianProduct.php
@@ -23,7 +23,7 @@ use function iterator_to_array;
  * @template TValue
  * @implements IteratorAggregate<array<TKey, TValue>>
  */
-class CartesianProduct implements IteratorAggregate, Countable
+final class CartesianProduct implements IteratorAggregate, Countable
 {
     /**
      * @var array<TKey, iterable<TValue>>

--- a/src/function.php
+++ b/src/function.php
@@ -2,6 +2,10 @@
 
 namespace BenTools\CartesianProduct;
 
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
+
 require_once __DIR__ . '/CartesianProduct.php';
 
 /**
@@ -11,6 +15,23 @@ require_once __DIR__ . '/CartesianProduct.php';
  * @return CartesianProduct<TKey, TValue>
  */
 function cartesian_product(array $set): CartesianProduct
+{
+    trigger_error(sprintf(
+        'The function %s() is deprecated since 1.5 and will be removed in 2.0. Use %s() instead.',
+        __FUNCTION__,
+        'BenTools\CartesianProduct\combinations'
+    ), E_USER_DEPRECATED);
+
+    return new CartesianProduct($set);
+}
+
+/**
+ * @template TKey
+ * @template TValue
+ * @param  array<TKey, iterable<TValue>> $set - A multidimensionnal array.
+ * @return CartesianProduct<TKey, TValue>
+ */
+function combinations(array $set): CartesianProduct
 {
     return new CartesianProduct($set);
 }

--- a/src/function.php
+++ b/src/function.php
@@ -5,8 +5,10 @@ namespace BenTools\CartesianProduct;
 require_once __DIR__ . '/CartesianProduct.php';
 
 /**
- * @param  array $set - A multidimensionnal array.
- * @return CartesianProduct
+ * @template TKey
+ * @template TValue
+ * @param  array<TKey, iterable<TValue>> $set - A multidimensionnal array.
+ * @return CartesianProduct<TKey, TValue>
  */
 function cartesian_product(array $set)
 {

--- a/src/function.php
+++ b/src/function.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/CartesianProduct.php';
  * @param  array<TKey, iterable<TValue>> $set - A multidimensionnal array.
  * @return CartesianProduct<TKey, TValue>
  */
-function cartesian_product(array $set)
+function cartesian_product(array $set): CartesianProduct
 {
     return new CartesianProduct($set);
 }

--- a/tests/CountableIterator.php
+++ b/tests/CountableIterator.php
@@ -5,6 +5,7 @@ namespace BenTools\CartesianProduct\Tests;
 use ArrayIterator;
 use Countable;
 use IteratorAggregate;
+use Traversable;
 
 /**
  * Class CountableIterator
@@ -25,7 +26,7 @@ final class CountableIterator implements IteratorAggregate, Countable
     }
 
 
-    public function getIterator(): \Traversable
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->items);
     }

--- a/tests/TestCartesianProductFunction.php
+++ b/tests/TestCartesianProductFunction.php
@@ -8,6 +8,9 @@ use PHPUnit\Framework\TestCase;
 
 use function BenTools\CartesianProduct\cartesian_product;
 
+use InvalidArgumentException;
+use stdClass;
+
 class TestCartesianProductFunction extends TestCase
 {
     /**
@@ -29,7 +32,7 @@ class TestCartesianProductFunction extends TestCase
 
     public function testSetWithEmptyArraySubset(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $set = [
             'fruits' => [
                 'strawberry',
@@ -84,14 +87,14 @@ class TestCartesianProductFunction extends TestCase
 
     public function testSetWithInvalidSubset(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $set = [
             'fruits' => [
                 'strawberry',
                 'raspberry',
                 'blueberry',
             ],
-            'vegetables' => new \stdClass(),
+            'vegetables' => new stdClass(),
             'drinks' => [
                 'beer',
                 'whiskey'

--- a/tests/TestCartesianProductFunction.php
+++ b/tests/TestCartesianProductFunction.php
@@ -1,0 +1,342 @@
+<?php
+
+namespace BenTools\CartesianProduct\Tests;
+
+error_reporting(E_ALL & ~E_USER_DEPRECATED);
+
+use PHPUnit\Framework\TestCase;
+
+use function BenTools\CartesianProduct\cartesian_product;
+
+class TestCartesianProductFunction extends TestCase
+{
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testLegacyCartesianProduct(array $cases, array $expected): void
+    {
+        $result = cartesian_product($cases);
+        $this->assertEquals($expected, $result->asArray());
+        $this->assertEquals($expected, $result->asArray());
+    }
+
+    public function testEmptySet(): void
+    {
+        $set = [];
+        $this->assertCount(0, iterator_to_array(cartesian_product($set)));
+        $this->assertEquals([], cartesian_product($set)->asArray());
+    }
+
+    public function testSetWithEmptyArraySubset(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $set = [
+            'fruits' => [
+                'strawberry',
+                'raspberry',
+                'blueberry',
+            ],
+            'vegetables' => [],
+            'drinks' => [
+                'beer',
+                'whiskey'
+            ]
+        ];
+        foreach (cartesian_product($set) as $product) {
+            continue;
+        }
+    }
+
+    public function testSetWithIteratorSubset(): void
+    {
+        $set = [
+            'fruit'     => [
+                'strawberry',
+                'raspberry',
+            ],
+            'vegetable' => new CountableIterator(['potato', function () {
+                return 'carrot';
+            }]),
+        ];
+
+        $expected = [
+            [
+                'fruit'     => 'strawberry',
+                'vegetable' => 'potato',
+            ],
+            [
+                'fruit'     => 'strawberry',
+                'vegetable' => 'carrot',
+            ],
+            [
+                'fruit'     => 'raspberry',
+                'vegetable' => 'potato',
+            ],
+            [
+                'fruit'     => 'raspberry',
+                'vegetable' => 'carrot',
+            ],
+        ];
+
+        $this->assertEquals($expected, cartesian_product($set)->asArray());
+
+    }
+
+    public function testSetWithInvalidSubset(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $set = [
+            'fruits' => [
+                'strawberry',
+                'raspberry',
+                'blueberry',
+            ],
+            'vegetables' => new \stdClass(),
+            'drinks' => [
+                'beer',
+                'whiskey'
+            ]
+        ];
+        foreach (cartesian_product($set) as $product) {
+            continue;
+        }
+    }
+
+    public function testCount(): void
+    {
+        $set = [
+            ['a', 'b', 'c', 'd', 'e', 'f'],
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        ];
+        $this->assertCount(60, cartesian_product($set));
+        $this->assertCount(60, cartesian_product($set)); // Assert we can call it several times
+    }
+
+    public function testRetrieveCurrentCombination(): void
+    {
+        $current = null;
+        $set = [
+            'hair' => [
+                'blond',
+                'dark',
+            ],
+            'skin' => [
+                'white',
+                'black',
+            ],
+            'eyes' => [
+                'blue',
+                function (array $combination) use (&$current) {
+                    if (null === $current) {
+                        $current = $combination;
+                    }
+                    return 'green';
+                },
+            ],
+            'gender' => [
+                'male',
+                'female',
+            ],
+        ];
+
+        foreach (cartesian_product($set) as $product) {
+            continue;
+        }
+        $this->assertNotNull($current);
+        $this->assertIsArray($current);
+        $this->assertArrayHasKey('hair', $current);
+        $this->assertArrayHasKey('skin', $current);
+        $this->assertArrayNotHasKey('eyes', $current);
+        $this->assertArrayNotHasKey('gender', $current);
+    }
+
+    public function dataProvider(): array
+    {
+        return [
+            'shapesAndColors'      => $this->shapesAndColors(),
+            'moreShapesThanColors' => $this->moreShapesThanColors(),
+            'moreColorsThanShapes' => $this->moreColorsThanShapes(),
+            'iCanHazClozures'      => $this->iCanHazClozures(),
+        ];
+    }
+
+    private function shapesAndColors(): array
+    {
+        return [
+            'cases'    => [
+                'color' => [
+                    'blue',
+                    'red',
+                    'green',
+                ],
+                'shape' => [
+                    'round',
+                    'square',
+                    'triangle',
+                ],
+            ],
+            'expected' => [
+                [
+                    'color' => 'blue',
+                    'shape' => 'round',
+                ],
+                [
+                    'color' => 'blue',
+                    'shape' => 'square',
+                ],
+                [
+                    'color' => 'blue',
+                    'shape' => 'triangle',
+                ],
+                [
+                    'color' => 'red',
+                    'shape' => 'round',
+                ],
+                [
+                    'color' => 'red',
+                    'shape' => 'square',
+                ],
+                [
+                    'color' => 'red',
+                    'shape' => 'triangle',
+                ],
+                [
+                    'color' => 'green',
+                    'shape' => 'round',
+                ],
+                [
+                    'color' => 'green',
+                    'shape' => 'square',
+                ],
+                [
+                    'color' => 'green',
+                    'shape' => 'triangle',
+                ],
+            ],
+        ];
+    }
+
+    private function moreShapesThanColors(): array
+    {
+        return [
+            'cases'    => [
+                'color' => [
+                    'blue',
+                    'red',
+                ],
+                'shape' => [
+                    'round',
+                    'square',
+                    'triangle',
+                ],
+            ],
+            'expected' => [
+                [
+                    'color' => 'blue',
+                    'shape' => 'round',
+                ],
+                [
+                    'color' => 'blue',
+                    'shape' => 'square',
+                ],
+                [
+                    'color' => 'blue',
+                    'shape' => 'triangle',
+                ],
+                [
+                    'color' => 'red',
+                    'shape' => 'round',
+                ],
+                [
+                    'color' => 'red',
+                    'shape' => 'square',
+                ],
+                [
+                    'color' => 'red',
+                    'shape' => 'triangle',
+                ],
+            ],
+        ];
+    }
+
+    private function moreColorsThanShapes(): array
+    {
+        return [
+            'cases'    => [
+                'color' => [
+                    'blue',
+                    'red',
+                    'green'
+                ],
+                'shape' => [
+                    'round',
+                    'square',
+                ],
+            ],
+            'expected' => [
+                [
+                    'color' => 'blue',
+                    'shape' => 'round',
+                ],
+                [
+                    'color' => 'blue',
+                    'shape' => 'square',
+                ],
+                [
+                    'color' => 'red',
+                    'shape' => 'round',
+                ],
+                [
+                    'color' => 'red',
+                    'shape' => 'square',
+                ],
+                [
+                    'color' => 'green',
+                    'shape' => 'round',
+                ],
+                [
+                    'color' => 'green',
+                    'shape' => 'square',
+                ],
+            ],
+        ];
+    }
+
+    private function iCanHazClozures(): array
+    {
+        return [
+            'cases'           => [
+                'color' => [
+                    'blue',
+                    function () {
+                        return 'red';
+                    },
+                ],
+                'shape' => [
+                    'round',
+                    function () {
+                        return 'square';
+                    },
+                ],
+            ],
+            'expected'        => [
+                [
+                    'color' => 'blue',
+                    'shape' => 'round',
+                ],
+                [
+                    'color' => 'blue',
+                    'shape' => 'square',
+                ],
+                [
+                    'color' => 'red',
+                    'shape' => 'round',
+                ],
+                [
+                    'color' => 'red',
+                    'shape' => 'square',
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/TestCombinationsFunction.php
+++ b/tests/TestCombinationsFunction.php
@@ -2,30 +2,29 @@
 
 namespace BenTools\CartesianProduct\Tests;
 
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+error_reporting(E_ALL);
+
 use PHPUnit\Framework\TestCase;
 
-use function BenTools\CartesianProduct\cartesian_product;
+use function BenTools\CartesianProduct\combinations;
 
-class TestCartesianProduct extends TestCase
+class TestCombinationsFunction extends TestCase
 {
-    use ArraySubsetAsserts;
-
     /**
      * @dataProvider dataProvider
      */
-    public function testCartesianProduct(array $cases, array $expected): void
+    public function testCombinations(array $cases, array $expected): void
     {
-        $result = cartesian_product($cases);
-        $this->assertArraySubset($expected, $result->asArray());
-        $this->assertArraySubset($expected, $result->asArray());
+        $result = combinations($cases);
+        $this->assertEquals($expected, $result->asArray());
+        $this->assertEquals($expected, $result->asArray());
     }
 
     public function testEmptySet(): void
     {
         $set = [];
-        $this->assertCount(0, iterator_to_array(cartesian_product($set)));
-        $this->assertEquals([], cartesian_product($set)->asArray());
+        $this->assertCount(0, iterator_to_array(combinations($set)));
+        $this->assertEquals([], combinations($set)->asArray());
     }
 
     public function testSetWithEmptyArraySubset(): void
@@ -43,7 +42,7 @@ class TestCartesianProduct extends TestCase
                 'whiskey'
             ]
         ];
-        foreach (cartesian_product($set) as $product) {
+        foreach (combinations($set) as $product) {
             continue;
         }
     }
@@ -79,7 +78,7 @@ class TestCartesianProduct extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, cartesian_product($set)->asArray());
+        $this->assertEquals($expected, combinations($set)->asArray());
 
     }
 
@@ -98,7 +97,7 @@ class TestCartesianProduct extends TestCase
                 'whiskey'
             ]
         ];
-        foreach (cartesian_product($set) as $product) {
+        foreach (combinations($set) as $product) {
             continue;
         }
     }
@@ -109,8 +108,8 @@ class TestCartesianProduct extends TestCase
             ['a', 'b', 'c', 'd', 'e', 'f'],
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
         ];
-        $this->assertCount(60, cartesian_product($set));
-        $this->assertCount(60, cartesian_product($set)); // Assert we can call it several times
+        $this->assertCount(60, combinations($set));
+        $this->assertCount(60, combinations($set)); // Assert we can call it several times
     }
 
     public function testRetrieveCurrentCombination(): void
@@ -140,7 +139,7 @@ class TestCartesianProduct extends TestCase
             ],
         ];
 
-        foreach (cartesian_product($set) as $product) {
+        foreach (combinations($set) as $product) {
             continue;
         }
         $this->assertNotNull($current);

--- a/tests/TestCombinationsFunction.php
+++ b/tests/TestCombinationsFunction.php
@@ -8,6 +8,9 @@ use PHPUnit\Framework\TestCase;
 
 use function BenTools\CartesianProduct\combinations;
 
+use InvalidArgumentException;
+use stdClass;
+
 class TestCombinationsFunction extends TestCase
 {
     /**
@@ -29,7 +32,7 @@ class TestCombinationsFunction extends TestCase
 
     public function testSetWithEmptyArraySubset(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $set = [
             'fruits' => [
                 'strawberry',
@@ -84,14 +87,14 @@ class TestCombinationsFunction extends TestCase
 
     public function testSetWithInvalidSubset(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $set = [
             'fruits' => [
                 'strawberry',
                 'raspberry',
                 'blueberry',
             ],
-            'vegetables' => new \stdClass(),
+            'vegetables' => new stdClass(),
             'drinks' => [
                 'beer',
                 'whiskey'


### PR DESCRIPTION
```
### Summary
- Updated code style check to use `php-cs-fixer`.
- Fixed code style issues.
- Deprecated the `cartesian_product` function and introduced a new `combinations` function as a replacement.
- Added return type declaration to `cartesian_product` function for better type clarity.
- Marked `CartesianProduct` class as final to prevent inheritance.
- Enhanced typing by adding generics and improving type declarations.

### Notes
- The deprecation of `cartesian_product` aligns with the introduction of `combinations` to provide better functionality and maintainability.
```